### PR TITLE
Correct error in docs

### DIFF
--- a/qm10/helper1.py
+++ b/qm10/helper1.py
@@ -107,7 +107,7 @@ def integrals(basis, mol):
 def a_funct(A):
     """
     Returns matrix raised to the -1/2 power 
-        as a numpy.ndarray
+        as a numpy array
     @A: psi4.core.Matrix
     """ 
 


### PR DESCRIPTION
Corrects erroneous line in documentation - output parameter is a numpy array, not a numpy ndarray.